### PR TITLE
2023.11.28 #2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     implementation 'com.google.code.gson:gson:2.10.1'
 
+    testImplementation 'org.mockito:mockito-inline:3.6.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 //	testImplementation 'org.springframework.security:spring-security-test'
     testImplementation "org.assertj:assertj-core:3.20.2"

--- a/src/main/java/tdd/groomingzone/domain/board/Board.java
+++ b/src/main/java/tdd/groomingzone/domain/board/Board.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import tdd.groomingzone.domain.comment.Comment;
 import tdd.groomingzone.domain.member.Member;
+import tdd.groomingzone.global.BaseEntity;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -14,7 +15,7 @@ import java.util.List;
 @Getter
 @Setter
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-public abstract class Board{
+public abstract class Board extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/src/main/java/tdd/groomingzone/domain/board/freeboard/FreeBoard.java
+++ b/src/main/java/tdd/groomingzone/domain/board/freeboard/FreeBoard.java
@@ -4,6 +4,7 @@ import lombok.*;
 import tdd.groomingzone.domain.board.Board;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,5 +20,6 @@ public class FreeBoard extends Board {
     public void modify(FreeBoardDto.Put putDto) {
         this.setTitle(putDto.getTitle());
         this.setContent(putDto.getContent());
+        this.setModifiedAt(LocalDateTime.now());
     }
 }

--- a/src/main/java/tdd/groomingzone/domain/board/freeboard/FreeBoard.java
+++ b/src/main/java/tdd/groomingzone/domain/board/freeboard/FreeBoard.java
@@ -2,6 +2,7 @@ package tdd.groomingzone.domain.board.freeboard;
 
 import lombok.*;
 import tdd.groomingzone.domain.board.Board;
+import tdd.groomingzone.domain.board.freeboard.dto.FreeBoardDto;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -17,9 +18,9 @@ public class FreeBoard extends Board {
         this.setContent(content);
     }
 
-    public void modify(FreeBoardDto.Put putDto) {
+    public void modify(FreeBoardDto.Put putDto, LocalDateTime modifiedAt) {
         this.setTitle(putDto.getTitle());
         this.setContent(putDto.getContent());
-        this.setModifiedAt(LocalDateTime.now());
+        this.setModifiedAt(modifiedAt);
     }
 }

--- a/src/main/java/tdd/groomingzone/domain/board/freeboard/FreeBoardDto.java
+++ b/src/main/java/tdd/groomingzone/domain/board/freeboard/FreeBoardDto.java
@@ -19,6 +19,8 @@ public class FreeBoardDto {
         private long boardId;
         private String title;
         private String content;
+        private String createdAt;
+        private String modifiedAt;
     }
 
     @Getter

--- a/src/main/java/tdd/groomingzone/domain/board/freeboard/FreeBoardService.java
+++ b/src/main/java/tdd/groomingzone/domain/board/freeboard/FreeBoardService.java
@@ -1,10 +1,14 @@
 package tdd.groomingzone.domain.board.freeboard;
 
+import tdd.groomingzone.domain.board.freeboard.dto.FreeBoardDto;
+
+import java.time.LocalDateTime;
+
 public interface FreeBoardService {
 
     FreeBoardDto.Response postFreeBoard(FreeBoardDto.Post postDto);
 
-    FreeBoardDto.Response putFreeBoard(long id, FreeBoardDto.Put putDto);
+    FreeBoardDto.Response putFreeBoard(long id, FreeBoardDto.Put putDto, LocalDateTime modifiedAt);
 
     FreeBoardDto.Response getFreeBoard(long id);
 

--- a/src/main/java/tdd/groomingzone/domain/board/freeboard/controller/FreeBoardController.java
+++ b/src/main/java/tdd/groomingzone/domain/board/freeboard/controller/FreeBoardController.java
@@ -4,17 +4,20 @@ import com.fasterxml.jackson.databind.annotation.NoClass;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import tdd.groomingzone.domain.board.freeboard.FreeBoardDto;
+import tdd.groomingzone.domain.board.freeboard.dto.FreeBoardDto;
 import tdd.groomingzone.domain.board.freeboard.FreeBoardService;
+import tdd.groomingzone.global.time.Time;
 
 @RestController
 @RequestMapping("/free-board")
 public class FreeBoardController {
 
     private final FreeBoardService freeBoardService;
+    private final Time time;
 
-    public FreeBoardController(FreeBoardService freeBoardService) {
+    public FreeBoardController(FreeBoardService freeBoardService, Time time) {
         this.freeBoardService = freeBoardService;
+        this.time = time;
     }
 
     @PostMapping
@@ -26,7 +29,7 @@ public class FreeBoardController {
     @PutMapping("/{free-board-id}")
     public ResponseEntity<FreeBoardDto.Response> putFreeBoard(@PathVariable("free-board-id") long freeBoardId,
                                                               @RequestBody FreeBoardDto.Put dto){
-        FreeBoardDto.Response responseDto = freeBoardService.putFreeBoard(freeBoardId, dto);
+        FreeBoardDto.Response responseDto = freeBoardService.putFreeBoard(freeBoardId, dto, time.now());
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 

--- a/src/main/java/tdd/groomingzone/domain/board/freeboard/dto/FreeBoardDto.java
+++ b/src/main/java/tdd/groomingzone/domain/board/freeboard/dto/FreeBoardDto.java
@@ -1,4 +1,4 @@
-package tdd.groomingzone.domain.board.freeboard;
+package tdd.groomingzone.domain.board.freeboard.dto;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/tdd/groomingzone/domain/board/freeboard/service/FreeBoardCommandService.java
+++ b/src/main/java/tdd/groomingzone/domain/board/freeboard/service/FreeBoardCommandService.java
@@ -3,8 +3,10 @@ package tdd.groomingzone.domain.board.freeboard.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tdd.groomingzone.domain.board.freeboard.FreeBoard;
-import tdd.groomingzone.domain.board.freeboard.FreeBoardDto;
+import tdd.groomingzone.domain.board.freeboard.dto.FreeBoardDto;
 import tdd.groomingzone.domain.board.freeboard.repository.FreeBoardRepository;
+
+import java.time.LocalDateTime;
 
 @Service
 public class FreeBoardCommandService {
@@ -21,8 +23,8 @@ public class FreeBoardCommandService {
     }
 
     @Transactional
-    public void update(FreeBoard entity, FreeBoardDto.Put putDto) {
-        entity.modify(putDto);
+    public void update(FreeBoard entity, FreeBoardDto.Put putDto, LocalDateTime modifiedAt) {
+        entity.modify(putDto, modifiedAt);
     }
 
     @Transactional

--- a/src/main/java/tdd/groomingzone/domain/board/freeboard/service/FreeBoardConverter.java
+++ b/src/main/java/tdd/groomingzone/domain/board/freeboard/service/FreeBoardConverter.java
@@ -2,7 +2,7 @@ package tdd.groomingzone.domain.board.freeboard.service;
 
 import org.springframework.stereotype.Service;
 import tdd.groomingzone.domain.board.freeboard.FreeBoard;
-import tdd.groomingzone.domain.board.freeboard.FreeBoardDto;
+import tdd.groomingzone.domain.board.freeboard.dto.FreeBoardDto;
 
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;

--- a/src/main/java/tdd/groomingzone/domain/board/freeboard/service/FreeBoardConverter.java
+++ b/src/main/java/tdd/groomingzone/domain/board/freeboard/service/FreeBoardConverter.java
@@ -4,6 +4,9 @@ import org.springframework.stereotype.Service;
 import tdd.groomingzone.domain.board.freeboard.FreeBoard;
 import tdd.groomingzone.domain.board.freeboard.FreeBoardDto;
 
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+
 @Service
 public class FreeBoardConverter {
 
@@ -19,6 +22,8 @@ public class FreeBoardConverter {
                 .boardId(entity.getId())
                 .title(entity.getTitle())
                 .content(entity.getContent())
+                .createdAt(entity.getCreatedAt().format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)))
+                .modifiedAt(entity.getModifiedAt().format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)))
                 .build();
     }
 }

--- a/src/main/java/tdd/groomingzone/domain/board/freeboard/service/FreeBoardServiceImpl.java
+++ b/src/main/java/tdd/groomingzone/domain/board/freeboard/service/FreeBoardServiceImpl.java
@@ -3,8 +3,10 @@ package tdd.groomingzone.domain.board.freeboard.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tdd.groomingzone.domain.board.freeboard.FreeBoard;
-import tdd.groomingzone.domain.board.freeboard.FreeBoardDto;
+import tdd.groomingzone.domain.board.freeboard.dto.FreeBoardDto;
 import tdd.groomingzone.domain.board.freeboard.FreeBoardService;
+
+import java.time.LocalDateTime;
 
 @Service
 public class FreeBoardServiceImpl implements FreeBoardService {
@@ -29,9 +31,9 @@ public class FreeBoardServiceImpl implements FreeBoardService {
 
     @Override
     @Transactional
-    public FreeBoardDto.Response putFreeBoard(long id, FreeBoardDto.Put putDto) {
+    public FreeBoardDto.Response putFreeBoard(long id, FreeBoardDto.Put putDto, LocalDateTime modifiedAt) {
         FreeBoard entity = freeBoardQueryService.readEntityById(id);
-        freeBoardCommandService.update(entity, putDto);
+        freeBoardCommandService.update(entity, putDto, modifiedAt);
         return freeBoardConverter.convertEntityToResponseDto(entity);
     }
 

--- a/src/main/java/tdd/groomingzone/domain/comment/Comment.java
+++ b/src/main/java/tdd/groomingzone/domain/comment/Comment.java
@@ -3,13 +3,14 @@ package tdd.groomingzone.domain.comment;
 import lombok.Getter;
 import lombok.Setter;
 import tdd.groomingzone.domain.board.Board;
+import tdd.groomingzone.global.BaseEntity;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
 @Setter
-public class Comment {
+public class Comment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/tdd/groomingzone/domain/member/Member.java
+++ b/src/main/java/tdd/groomingzone/domain/member/Member.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import tdd.groomingzone.domain.board.recruitment.Recruitment;
 import tdd.groomingzone.domain.board.review.Review;
 import tdd.groomingzone.domain.board.freeboard.FreeBoard;
+import tdd.groomingzone.global.BaseEntity;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -13,7 +14,7 @@ import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/tdd/groomingzone/global/BaseEntity.java
+++ b/src/main/java/tdd/groomingzone/global/BaseEntity.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Setter
 public class BaseEntity {
 
-    @Column(name = "CREATE_AT")
+    @Column(name = "CREATED_AT")
     private LocalDateTime createdAt = LocalDateTime.now();
 
     @Column(name = "LAST_MODIFIED_AT")

--- a/src/main/java/tdd/groomingzone/global/BaseEntity.java
+++ b/src/main/java/tdd/groomingzone/global/BaseEntity.java
@@ -1,0 +1,20 @@
+package tdd.groomingzone.global;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@Setter
+public class BaseEntity {
+
+    @Column(name = "CREATE_AT")
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "LAST_MODIFIED_AT")
+    private LocalDateTime modifiedAt = LocalDateTime.now();
+}

--- a/src/main/java/tdd/groomingzone/global/time/JodaTime.java
+++ b/src/main/java/tdd/groomingzone/global/time/JodaTime.java
@@ -1,0 +1,14 @@
+package tdd.groomingzone.global.time;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class JodaTime implements Time{
+
+    @Override
+    public LocalDateTime now() {
+        return LocalDateTime.now();
+    }
+}

--- a/src/main/java/tdd/groomingzone/global/time/Time.java
+++ b/src/main/java/tdd/groomingzone/global/time/Time.java
@@ -1,0 +1,7 @@
+package tdd.groomingzone.global.time;
+
+import java.time.LocalDateTime;
+
+public interface Time {
+    LocalDateTime now();
+}

--- a/src/test/java/tdd/groomingzone/board/freeboard/FreeBoardCommandServiceTest.java
+++ b/src/test/java/tdd/groomingzone/board/freeboard/FreeBoardCommandServiceTest.java
@@ -4,15 +4,21 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tdd.groomingzone.util.StubTime;
 import tdd.groomingzone.domain.board.freeboard.FreeBoard;
-import tdd.groomingzone.domain.board.freeboard.FreeBoardDto;
+import tdd.groomingzone.domain.board.freeboard.dto.FreeBoardDto;
 import tdd.groomingzone.domain.board.freeboard.repository.FreeBoardRepository;
 import tdd.groomingzone.domain.board.freeboard.service.FreeBoardCommandService;
 
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,10 +59,16 @@ class FreeBoardCommandServiceTest {
         putDto.setTitle("modifiedTitle");
         putDto.setContent("modifiedContent");
 
-        freeBoardCommandService.update(testEntity, putDto);
+        try(MockedStatic<StubTime> modifiedAt = mockStatic(StubTime.class)){
+            LocalDateTime fakeModifiedTime = LocalDateTime.of(2023, 11, 28, 22, 30 ,10);
+            given(StubTime.of(anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt())).willReturn(fakeModifiedTime);
 
-        assertThat(testEntity.getTitle()).isEqualTo(putDto.getTitle());
-        assertThat(testEntity.getContent()).isEqualTo(putDto.getContent());
+            freeBoardCommandService.update(testEntity, putDto, fakeModifiedTime);
+
+            assertThat(testEntity.getTitle()).isEqualTo(putDto.getTitle());
+            assertThat(testEntity.getContent()).isEqualTo(putDto.getContent());
+            assertThat(testEntity.getModifiedAt()).isEqualTo(fakeModifiedTime);
+        }
     }
 
     @Test

--- a/src/test/java/tdd/groomingzone/board/freeboard/FreeBoardControllerTest.java
+++ b/src/test/java/tdd/groomingzone/board/freeboard/FreeBoardControllerTest.java
@@ -10,17 +10,17 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
-import tdd.groomingzone.domain.board.freeboard.FreeBoardDto;
+import tdd.groomingzone.domain.board.freeboard.dto.FreeBoardDto;
 import tdd.groomingzone.domain.board.freeboard.controller.FreeBoardController;
 import tdd.groomingzone.domain.board.freeboard.service.FreeBoardServiceImpl;
+import tdd.groomingzone.util.StubTime;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
@@ -45,6 +45,9 @@ class FreeBoardControllerTest {
 
     @MockBean
     private FreeBoardServiceImpl freeBoardService;
+
+    @MockBean
+    private StubTime stubTime;
 
     @Test
     @DisplayName("정상적인 게시글 등록 요청 테스트")
@@ -125,7 +128,7 @@ class FreeBoardControllerTest {
 
         String content = gson.toJson(testPut);
 
-        given(freeBoardService.putFreeBoard(anyLong(), any())).willReturn(testResponse);
+        given(freeBoardService.putFreeBoard(anyLong(), any(), any())).willReturn(testResponse);
 
         // when // then
         mockMvc.perform(

--- a/src/test/java/tdd/groomingzone/board/freeboard/FreeBoardControllerTest.java
+++ b/src/test/java/tdd/groomingzone/board/freeboard/FreeBoardControllerTest.java
@@ -14,6 +14,9 @@ import tdd.groomingzone.domain.board.freeboard.FreeBoardDto;
 import tdd.groomingzone.domain.board.freeboard.controller.FreeBoardController;
 import tdd.groomingzone.domain.board.freeboard.service.FreeBoardServiceImpl;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -60,6 +63,8 @@ class FreeBoardControllerTest {
                 .boardId(testId)
                 .title(testTitle)
                 .content(testContent)
+                .createdAt(LocalDateTime.now().format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)))
+                .modifiedAt(LocalDateTime.now().format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)))
                 .build();
 
         String content = gson.toJson(testPost);
@@ -87,9 +92,11 @@ class FreeBoardControllerTest {
                         ),
                         responseFields(
                                 List.of(
-                                        fieldWithPath("boardId").type(JsonFieldType.NUMBER).description("게시글 식별자"),           // (5)
+                                        fieldWithPath("boardId").type(JsonFieldType.NUMBER).description("게시글 식별자"),
                                         fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
-                                        fieldWithPath("content").type(JsonFieldType.STRING).description("내용")
+                                        fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                        fieldWithPath("createdAt").type(JsonFieldType.STRING).description("작성일"),
+                                        fieldWithPath("modifiedAt").type(JsonFieldType.STRING).description("수정일")
                                 )
                         )
                 ));
@@ -112,6 +119,8 @@ class FreeBoardControllerTest {
                 .boardId(testId)
                 .title(testTitle)
                 .content(testContent)
+                .createdAt(LocalDateTime.now().format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)))
+                .modifiedAt(LocalDateTime.now().format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)))
                 .build();
 
         String content = gson.toJson(testPut);
@@ -141,9 +150,11 @@ class FreeBoardControllerTest {
                         ),
                         responseFields(
                                 List.of(
-                                        fieldWithPath("boardId").type(JsonFieldType.NUMBER).description("게시글 식별자"),           // (5)
+                                        fieldWithPath("boardId").type(JsonFieldType.NUMBER).description("게시글 식별자"),
                                         fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
-                                        fieldWithPath("content").type(JsonFieldType.STRING).description("내용")
+                                        fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                        fieldWithPath("createdAt").type(JsonFieldType.STRING).description("작성일"),
+                                        fieldWithPath("modifiedAt").type(JsonFieldType.STRING).description("수정일")
                                 )
                         )
                 ));
@@ -161,6 +172,8 @@ class FreeBoardControllerTest {
                 .builder()
                 .title(testTitle)
                 .content(testContent)
+                .createdAt(LocalDateTime.now().format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)))
+                .modifiedAt(LocalDateTime.now().format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)))
                 .build();
 
         given(freeBoardService.getFreeBoard(anyLong())).willReturn(testResponse);
@@ -182,9 +195,11 @@ class FreeBoardControllerTest {
                         ),
                         responseFields(
                                 List.of(
-                                        fieldWithPath("boardId").type(JsonFieldType.NUMBER).description("게시글 식별자"),           // (5)
+                                        fieldWithPath("boardId").type(JsonFieldType.NUMBER).description("게시글 식별자"),
                                         fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
-                                        fieldWithPath("content").type(JsonFieldType.STRING).description("내용")
+                                        fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                        fieldWithPath("createdAt").type(JsonFieldType.STRING).description("작성일"),
+                                        fieldWithPath("modifiedAt").type(JsonFieldType.STRING).description("수정일")
                                 )
                         )
                 ));

--- a/src/test/java/tdd/groomingzone/board/freeboard/FreeBoardConverterTest.java
+++ b/src/test/java/tdd/groomingzone/board/freeboard/FreeBoardConverterTest.java
@@ -23,7 +23,6 @@ class FreeBoardConverterTest {
         FreeBoard entity = freeBoardConverter.convertPostDtoToEntity(postDto);
 
         assertThat(postDto.getTitle()).isEqualTo(entity.getTitle());
-
         assertThat(postDto.getContent()).isEqualTo(entity.getContent());
     }
 

--- a/src/test/java/tdd/groomingzone/board/freeboard/FreeBoardConverterTest.java
+++ b/src/test/java/tdd/groomingzone/board/freeboard/FreeBoardConverterTest.java
@@ -2,7 +2,7 @@ package tdd.groomingzone.board.freeboard;
 
 import org.junit.jupiter.api.Test;
 import tdd.groomingzone.domain.board.freeboard.FreeBoard;
-import tdd.groomingzone.domain.board.freeboard.FreeBoardDto;
+import tdd.groomingzone.domain.board.freeboard.dto.FreeBoardDto;
 import tdd.groomingzone.domain.board.freeboard.service.FreeBoardConverter;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/tdd/groomingzone/board/freeboard/FreeBoardTest.java
+++ b/src/test/java/tdd/groomingzone/board/freeboard/FreeBoardTest.java
@@ -1,10 +1,17 @@
 package tdd.groomingzone.board.freeboard;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import tdd.groomingzone.util.StubTime;
 import tdd.groomingzone.domain.board.freeboard.FreeBoard;
-import tdd.groomingzone.domain.board.freeboard.FreeBoardDto;
+import tdd.groomingzone.domain.board.freeboard.dto.FreeBoardDto;
+
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mockStatic;
 
 class FreeBoardTest {
 
@@ -20,9 +27,14 @@ class FreeBoardTest {
         putDto.setTitle("modifiedTitle");
         putDto.setContent("modifiedContent");
 
-        testEntity.modify(putDto);
+        try(MockedStatic<StubTime> modifiedAt = mockStatic(StubTime.class)){
+            LocalDateTime fakeModifiedTime = LocalDateTime.of(2023, 11, 28, 22, 30, 10);
+            given(StubTime.of(anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt())).willReturn(fakeModifiedTime);
 
-        assertThat(testEntity.getTitle()).isEqualTo(putDto.getTitle());
-        assertThat(testEntity.getContent()).isEqualTo(putDto.getContent());
+            testEntity.modify(putDto, fakeModifiedTime);
+            assertThat(testEntity.getTitle()).isEqualTo(putDto.getTitle());
+            assertThat(testEntity.getContent()).isEqualTo(putDto.getContent());
+            assertThat(testEntity.getModifiedAt()).isEqualTo(fakeModifiedTime);
+        }
     }
 }

--- a/src/test/java/tdd/groomingzone/util/StubTime.java
+++ b/src/test/java/tdd/groomingzone/util/StubTime.java
@@ -1,0 +1,25 @@
+package tdd.groomingzone.util;
+
+import org.springframework.boot.test.mock.mockito.MockBean;
+import tdd.groomingzone.global.time.Time;
+
+import java.time.LocalDateTime;
+
+@MockBean
+public class StubTime implements Time {
+
+    private final LocalDateTime currentTime;
+
+    public StubTime(LocalDateTime currentTime){
+        this.currentTime = currentTime;
+    }
+
+    public static LocalDateTime of(int year, int month, int day, int hour, int minute, int second){
+        return LocalDateTime.of(year, month, day, hour, minute, second);
+    }
+
+    @Override
+    public LocalDateTime now() {
+        return this.currentTime;
+    }
+}


### PR DESCRIPTION
## 데이터 생성 - 수정 시간 반영
- 데이터 수정 시 수정 시간으로 시간 변경
- 원활한 테스트를 위한 유틸리티 클래스 생성
    - Time 인터페이스 및  JodaTime, StubTime 클래스 생성
- 클래스 수정 및 생성
    - BaseEntity 클래스 생성
    - FreeBoardController 클래스에 Time time 필드 주입  
- 메서드 수정
    - FreeBoard#modify(); 메서드에 LocalDateTime modifiedAt 인자 추가
    - FreeBoardCommandService#update(); 메서드에 LocalDateTime modifiedAt 인자 추가
    - FreeBoardService#putFreeBoard(); 메서드에 LocalDateTime modifiedAt 인자 추가
- 테스트 수정
    - 전술한 테스트들의 메서드 수정 