### PR TITLE
24.0.1.25 #1

### DIFF
--- a/src/main/java/tdd/groomingzone/auth/oauth2/OAuth2MemberService.java
+++ b/src/main/java/tdd/groomingzone/auth/oauth2/OAuth2MemberService.java
@@ -42,11 +42,11 @@ public class OAuth2MemberService extends DefaultOAuth2UserService {
         List<String> roles = rolesGenerator.generateMemberRoles(email, "고객");
         List<GrantedAuthority> authorities = authorityUtils.createAuthorities(roles);
 
-        saveMemberIfNotPresent(email, attributes.getName(), roles);
+        saveMemberIfNotPresent(email, attributes.getName(), roles, registrationId);
         return new CustomOAuth2User(registrationId, userAttributes, authorities, email);
     }
 
-    private void saveMemberIfNotPresent(String email, String nickName, List<String> roles){
+    private void saveMemberIfNotPresent(String email, String nickName, List<String> roles, String registrationId){
         if(memberEntitiyRepository.findByEmail(email).isEmpty()){
             LocalDateTime createTime = LocalDateTime.now();
             MemberEntity member = MemberEntity.builder()
@@ -56,6 +56,7 @@ public class OAuth2MemberService extends DefaultOAuth2UserService {
                     .roles(roles)
                     .createdAt(createTime)
                     .modifiedAt(createTime)
+                    .provider(registrationId)
                     .build();
             memberEntitiyRepository.save(member);
         }

--- a/src/main/java/tdd/groomingzone/auth/oauth2/OAuthAttributes.java
+++ b/src/main/java/tdd/groomingzone/auth/oauth2/OAuthAttributes.java
@@ -17,19 +17,15 @@ public class OAuthAttributes {
     private final String nameAttributesKey;
     private final String name;
     private final String email;
-    private final String gender;
-    private final String ageRange;
     private final String profileImageUrl;
 
     @Builder
     public OAuthAttributes(Map<String, Object> attributes, String nameAttributesKey,
-                           String name, String email, String gender, String ageRange, String profileImageUrl) {
+                           String name, String email, String profileImageUrl) {
         this.attributes = attributes;
         this.nameAttributesKey = nameAttributesKey;
         this.name = name;
         this.email = email;
-        this.gender = gender;
-        this.ageRange = ageRange;
         this.profileImageUrl = profileImageUrl;
     }
 

--- a/src/main/java/tdd/groomingzone/auth/utils/handler/OAuth2MemberSuccessHandler.java
+++ b/src/main/java/tdd/groomingzone/auth/utils/handler/OAuth2MemberSuccessHandler.java
@@ -1,7 +1,7 @@
 package tdd.groomingzone.auth.utils.handler;
 
 import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import tdd.groomingzone.auth.oauth2.CustomOAuth2User;
 import tdd.groomingzone.auth.application.service.SuccessfulAuthenticationProcessor;
 import tdd.groomingzone.global.exception.BusinessException;
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+public class OAuth2MemberSuccessHandler implements AuthenticationSuccessHandler {
 
     private final MemberEntitiyRepository memberEntitiyRepository;
     private final SuccessfulAuthenticationProcessor successfulAuthenticationProcessor;

--- a/src/main/java/tdd/groomingzone/comment/common/CommentEntity.java
+++ b/src/main/java/tdd/groomingzone/comment/common/CommentEntity.java
@@ -5,6 +5,7 @@ import lombok.*;
 import tdd.groomingzone.global.BaseEntity;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -27,9 +28,11 @@ public class CommentEntity extends BaseEntity {
     private String content;
 
     @Builder
-    public CommentEntity(Long boardId, Long writerId, String content){
+    public CommentEntity(Long boardId, Long writerId, String content, LocalDateTime createdAt, LocalDateTime modifiedAt){
         this.boardId = boardId;
         this.writerId = writerId;
         this.content = content;
+        setCreatedAt(createdAt);
+        setModifiedAt(modifiedAt);
     }
 }

--- a/src/main/java/tdd/groomingzone/comment/freeboardcomment/adapter/out/FreeBoardCommentMapper.java
+++ b/src/main/java/tdd/groomingzone/comment/freeboardcomment/adapter/out/FreeBoardCommentMapper.java
@@ -18,6 +18,8 @@ public class FreeBoardCommentMapper {
                 .boardId(freeBoardComment.getBoardId())
                 .writerId(freeBoardComment.getWriterId())
                 .content(freeBoardComment.getContent())
+                .createdAt(freeBoardComment.getCreatedAt())
+                .modifiedAt(freeBoardComment.getModifiedAt())
                 .build();
     }
 

--- a/src/main/java/tdd/groomingzone/comment/freeboardcomment/application/service/PostFreeBoardCommentService.java
+++ b/src/main/java/tdd/groomingzone/comment/freeboardcomment/application/service/PostFreeBoardCommentService.java
@@ -34,14 +34,17 @@ public class PostFreeBoardCommentService implements PostFreeBoardCommentUseCase 
         FreeBoardEntityQueryResult selectFreeBoardQueryResult = loadFreeBoardPort.loadFreeBoardById(postFreeBoardCommentCommand.getBoardId());
         Member freeBoardWriter = loadMemberPort.findMemberById(selectFreeBoardQueryResult.getWriterId());
         Member commentWriter = loadMemberPort.findMemberById(postFreeBoardCommentCommand.getWriterId());
+
+        LocalDateTime writeCommentTime = LocalDateTime.now();
         FreeBoardComment freeBoardComment = freeBoardCommentPublisher.createFreeBoardComment(selectFreeBoardQueryResult,
                 freeBoardWriter,
                 commentWriter,
                 postFreeBoardCommentCommand.getContent(),
-                LocalDateTime.now(),
-                LocalDateTime.now());
+                writeCommentTime,
+                writeCommentTime);
 
         FreeBoardCommentEntityResult saveQueryResult = saveFreeBoardCommentPort.save(freeBoardComment);
+
         return SingleFreeBoardCommentResponse.of(saveQueryResult.getContent(),
                 saveQueryResult.getCreatedAt(),
                 saveQueryResult.getModifiedAt(),

--- a/src/main/java/tdd/groomingzone/global/configuration/SecurityConfig.java
+++ b/src/main/java/tdd/groomingzone/global/configuration/SecurityConfig.java
@@ -73,7 +73,6 @@ public class SecurityConfig {
                         .userInfoEndpoint()
                         .userService(OAuth2MemberService))
                 .authorizeHttpRequests(authorize -> authorize
-                        .antMatchers(HttpMethod.GET, "/free-board").hasRole("CUSTOMER")
                         .antMatchers(HttpMethod.POST, "/free-board/**", "/review/**", "/recruitment/**", "/comment/**").hasRole("CUSTOMER")
                         .antMatchers(HttpMethod.PUT, "/free-board/**", "/review/**", "/recruitment/**", "/comment/**", "/member/**").hasRole("CUSTOMER")
                         .antMatchers(HttpMethod.DELETE, "/free-board/**", "/review/**", "/recruitment/**", "/comment/**", "/member/**").hasRole("CUSTOMER")
@@ -95,7 +94,7 @@ public class SecurityConfig {
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowCredentials(true);
         configuration.addAllowedHeader("*");
-        configuration.setExposedHeaders(Arrays.asList("Authorization", "Refresh", "MemberId"));
+        configuration.setExposedHeaders(Arrays.asList("Authorization", "Refresh"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/tdd/groomingzone/member/adapter/out/persistence/MemberEntity.java
+++ b/src/main/java/tdd/groomingzone/member/adapter/out/persistence/MemberEntity.java
@@ -32,6 +32,9 @@ public class MemberEntity extends BaseEntity {
     @Column(name = "PHONE_NUMBER")
     private String phoneNumber;
 
+    @Column(name = "PROVIDER")
+    private String provider;
+
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(
             name = "MEMBER_ROLES",
@@ -40,13 +43,14 @@ public class MemberEntity extends BaseEntity {
     private List<String> roles = new ArrayList<>();
 
     @Builder
-    private MemberEntity(long id, String email, String password, String nickName, String phoneNumber, List<String>roles, LocalDateTime createdAt, LocalDateTime modifiedAt){
+    private MemberEntity(long id, String email, String password, String nickName, String phoneNumber, List<String>roles, LocalDateTime createdAt, LocalDateTime modifiedAt, String provider){
         this.id = id;
         this.email = email;
         this.password = password;
         this.nickName = nickName;
         this.phoneNumber = phoneNumber;
         this.roles = roles;
+        this.provider = provider;
         this.setCreatedAt(createdAt);
         this.setModifiedAt(modifiedAt);
     }

--- a/src/main/java/tdd/groomingzone/member/adapter/out/persistence/MemberMapper.java
+++ b/src/main/java/tdd/groomingzone/member/adapter/out/persistence/MemberMapper.java
@@ -26,6 +26,7 @@ public class MemberMapper {
                 .nickName(findMember.getNickName())
                 .phoneNumber(findMember.getPhoneNumber())
                 .role(findMember.getRoles().get(0))
+                .provider(findMember.getProvider())
                 .build();
     }
 
@@ -37,6 +38,7 @@ public class MemberMapper {
                 .password(passwordEncoder.encode(member.getPassword()))
                 .roles(memberEntityRolesGenerator.generateMemberRoles(member.getEmail(), member.getRole()))
                 .phoneNumber(member.getPhoneNumber())
+                .provider(member.getProvider())
                 .build();
     }
 }

--- a/src/main/java/tdd/groomingzone/member/application/port/in/MemberCommandResponse.java
+++ b/src/main/java/tdd/groomingzone/member/application/port/in/MemberCommandResponse.java
@@ -9,16 +9,18 @@ public final class MemberCommandResponse {
     private final String nickName;
     private final String phoneNumber;
     private final String role;
+    private final String provider;
 
-    private MemberCommandResponse(long memberId, String email, String nickName, String phoneNumber, String role){
+    private MemberCommandResponse(long memberId, String email, String nickName, String phoneNumber, String role, String provider){
         this.memberId = memberId;
         this.email = email;
         this.nickName = nickName;
         this.phoneNumber = phoneNumber;
         this.role = role;
+        this.provider = provider;
     }
 
-    public static MemberCommandResponse of(long memberId, String email, String nickName, String phoneNumber, String role){
-        return new MemberCommandResponse(memberId, email, nickName, phoneNumber, role);
+    public static MemberCommandResponse of(long memberId, String email, String nickName, String phoneNumber, String role, String provider){
+        return new MemberCommandResponse(memberId, email, nickName, phoneNumber, role, provider);
     }
 }

--- a/src/main/java/tdd/groomingzone/member/application/service/PostMemberService.java
+++ b/src/main/java/tdd/groomingzone/member/application/service/PostMemberService.java
@@ -12,6 +12,8 @@ import tdd.groomingzone.member.application.port.in.MemberCommandResponse;
 import tdd.groomingzone.member.application.port.out.SaveMemberPort;
 import tdd.groomingzone.member.domain.Member;
 
+import java.time.LocalDateTime;
+
 @Service
 public class PostMemberService implements PostMemberUseCase {
 
@@ -27,6 +29,7 @@ public class PostMemberService implements PostMemberUseCase {
     @Transactional
     public MemberCommandResponse postMember(PostMemberCommand command) {
         verifyEmailDuplicate(command.getEmail());
+        LocalDateTime createAt = LocalDateTime.now();
         Member member = Member.builder()
                 .memberId(0)
                 .email(command.getEmail())
@@ -34,13 +37,17 @@ public class PostMemberService implements PostMemberUseCase {
                 .nickName(command.getNickName())
                 .phoneNumber(command.getPhoneNumber())
                 .role(command.getRole())
+                .createdAt(createAt)
+                .modifiedAt(createAt)
+                .provider("SERVER")
                 .build();
         Member savedMember = saveMemberPort.save(member);
         return MemberCommandResponse.of(savedMember.getMemberId(),
                 savedMember.getEmail(),
                 savedMember.getNickName(),
                 savedMember.getPhoneNumber(),
-                savedMember.getRole());
+                savedMember.getRole(),
+                savedMember.getProvider());
     }
 
     private void verifyEmailDuplicate(String requestEmail) {

--- a/src/main/java/tdd/groomingzone/member/domain/Member.java
+++ b/src/main/java/tdd/groomingzone/member/domain/Member.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import tdd.groomingzone.global.exception.BusinessException;
 import tdd.groomingzone.global.exception.ExceptionCode;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class Member {
     private final long memberId;
@@ -13,24 +15,31 @@ public class Member {
     private String nickName;
     private PhoneNumber phoneNumber;
     private Role role;
+    private final Provider provider;
+    private final LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
 
     @Builder
-    private Member(long memberId, String email, String password, String nickName, String phoneNumber, String role) {
+    private Member(long memberId, String email, String password, String nickName, String phoneNumber, String role, String provider, LocalDateTime createdAt, LocalDateTime modifiedAt) {
         this.memberId = memberId;
         this.email = Email.of(email);
         this.password = Password.of(password);
         this.nickName = nickName;
         this.phoneNumber = PhoneNumber.of(phoneNumber);
         this.role = Role.of(role);
+        this.provider = Provider.of(provider);
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
     }
 
-    public void modify(String email, String password, String nickName, String phoneNumber, String role) {
+    public void modify(String email, String password, String nickName, String phoneNumber, String role, LocalDateTime modifiedAt) {
         this.email = Email.of(email);
         this.password = Password.of(password);
         this.nickName = nickName;
         this.phoneNumber = PhoneNumber.of(phoneNumber);
         validateRole(role);
-        this.role = Role.valueOf(role);
+        this.role = Role.of(role);
+        this.modifiedAt = modifiedAt;
     }
 
     private void validateRole(String inputRole) {
@@ -63,6 +72,10 @@ public class Member {
         return role.equals(Role.ADMIN);
     }
 
+    public String getProvider(){
+        return this.provider.getProvider();
+    }
+
     @Getter
     public enum Role {
         ADMIN("관리자"),
@@ -78,6 +91,27 @@ public class Member {
         public static Role of(String inputRole){
             try{
                 return Role.valueOf(inputRole);
+            }catch (IllegalArgumentException e){
+                throw new BusinessException(ExceptionCode.INVALID_ROLE);
+            }
+        }
+    }
+
+    @Getter
+    public enum Provider{
+        SERVER("SERVER"),
+        KAKAO("KAKAO"),
+        NAVER("NAVER");
+
+        private final String provider;
+
+        Provider(String provider) {
+            this.provider = provider;
+        }
+
+        public static Provider of(String input){
+            try{
+                return Provider.valueOf(input);
             }catch (IllegalArgumentException e){
                 throw new BusinessException(ExceptionCode.INVALID_ROLE);
             }

--- a/src/test/java/tdd/groomingzone/auth/adapter/in/web/SignOutControllerTest.java
+++ b/src/test/java/tdd/groomingzone/auth/adapter/in/web/SignOutControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 import tdd.groomingzone.auth.application.port.in.usecase.SignOutUseCase;
 import tdd.groomingzone.auth.utils.CookieManager;
@@ -21,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static tdd.groomingzone.global.utils.ApiDocumentUtils.getRequestPreProcessor;
 import static tdd.groomingzone.global.utils.ApiDocumentUtils.getResponsePreProcessor;
 
-@WebMvcTest(controllers = SignOutController.class,
+@WebMvcTest(controllers = {SignOutController.class},
         excludeAutoConfiguration = {SecurityAutoConfiguration.class})
 @AutoConfigureRestDocs
 class SignOutControllerTest {
@@ -30,6 +31,9 @@ class SignOutControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private SecurityFilterChain oauth2SecurityFilterChain;
 
     @MockBean
     private SignOutUseCase signOutUseCase;

--- a/src/test/java/tdd/groomingzone/comment/freeboardcomment/adapter/in/web/DeleteFreeBoardCommentControllerTest.java
+++ b/src/test/java/tdd/groomingzone/comment/freeboardcomment/adapter/in/web/DeleteFreeBoardCommentControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 import tdd.groomingzone.comment.freeboardcomment.application.port.in.usecase.DeleteFreeBoardCommentUseCase;
 
@@ -20,13 +21,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static tdd.groomingzone.global.utils.ApiDocumentUtils.getRequestPreProcessor;
 import static tdd.groomingzone.global.utils.ApiDocumentUtils.getResponsePreProcessor;
 
-@WebMvcTest(controllers = DeleteFreeBoardCommentController.class,
+@WebMvcTest(controllers = {DeleteFreeBoardCommentController.class},
         excludeAutoConfiguration = {SecurityAutoConfiguration.class})
 @AutoConfigureRestDocs
 class DeleteFreeBoardCommentControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private SecurityFilterChain oauth2SecurityFilterChain;
 
     @MockBean
     private DeleteFreeBoardCommentUseCase deleteFreeBoardCommentUseCase;

--- a/src/test/java/tdd/groomingzone/comment/freeboardcomment/adapter/in/web/GetFreeBoardCommentControllerTest.java
+++ b/src/test/java/tdd/groomingzone/comment/freeboardcomment/adapter/in/web/GetFreeBoardCommentControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 import tdd.groomingzone.post.common.WriterInfo;
 import tdd.groomingzone.comment.freeboardcomment.application.port.in.dto.response.MultiFreeBoardCommentResponse;
@@ -16,6 +17,7 @@ import tdd.groomingzone.comment.freeboardcomment.application.port.in.dto.respons
 import tdd.groomingzone.comment.freeboardcomment.application.port.in.usecase.GetFreeBoardCommentUseCase;
 import tdd.groomingzone.global.pagedresponse.PageInfo;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -42,6 +44,9 @@ import static tdd.groomingzone.global.utils.ApiDocumentUtils.getResponsePreProce
 class GetFreeBoardCommentControllerTest {
 
     @MockBean
+    private SecurityFilterChain oauth2SecurityFilterChain;
+
+    @MockBean
     private GetFreeBoardCommentUseCase getFreeBoardCommentUseCase;
 
     @Autowired
@@ -52,14 +57,7 @@ class GetFreeBoardCommentControllerTest {
     void testGetFreeBoardComment() throws Exception {
         String testContent = "content";
 
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         LocalDateTime testCreatedAt = LocalDateTime.now();
         LocalDateTime testModifiedAt = LocalDateTime.now();

--- a/src/test/java/tdd/groomingzone/comment/freeboardcomment/adapter/in/web/PostFreeBoardCommentControllerTest.java
+++ b/src/test/java/tdd/groomingzone/comment/freeboardcomment/adapter/in/web/PostFreeBoardCommentControllerTest.java
@@ -10,11 +10,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 import tdd.groomingzone.post.common.WriterInfo;
 import tdd.groomingzone.comment.freeboardcomment.application.port.in.dto.response.SingleFreeBoardCommentResponse;
 import tdd.groomingzone.comment.freeboardcomment.application.port.in.usecase.PostFreeBoardCommentUseCase;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -48,6 +50,9 @@ class PostFreeBoardCommentControllerTest {
     @MockBean
     private PostFreeBoardCommentUseCase postFreeBoardCommentUseCase;
 
+    @MockBean
+    private SecurityFilterChain oauth2SecurityFilterChain;
+
     @Test
     @DisplayName("정상적인 게시글 등록 요청 테스트")
     void postFreeBoardTest() throws Exception {
@@ -58,14 +63,7 @@ class PostFreeBoardCommentControllerTest {
 
         String content = gson.toJson(testPost);
 
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
         LocalDateTime testCreatedAt = LocalDateTime.now();
         LocalDateTime testModifiedAt = LocalDateTime.now();
 

--- a/src/test/java/tdd/groomingzone/comment/freeboardcomment/adapter/in/web/PutFreeBoardCommentControllerTest.java
+++ b/src/test/java/tdd/groomingzone/comment/freeboardcomment/adapter/in/web/PutFreeBoardCommentControllerTest.java
@@ -10,11 +10,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 import tdd.groomingzone.post.common.WriterInfo;
 import tdd.groomingzone.comment.freeboardcomment.application.port.in.dto.response.SingleFreeBoardCommentResponse;
 import tdd.groomingzone.comment.freeboardcomment.application.port.in.usecase.PutFreeBoardCommentUseCase;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -48,6 +50,9 @@ public class PutFreeBoardCommentControllerTest {
     @MockBean
     private PutFreeBoardCommentUseCase putFreeBoardCommentUseCase;
 
+    @MockBean
+    private SecurityFilterChain oauth2SecurityFilterChain;
+
     @Test
     @DisplayName("댓글을 수정한다.")
     void testPutFreeBoardComment() throws Exception {
@@ -57,14 +62,7 @@ public class PutFreeBoardCommentControllerTest {
 
         String content = gson.toJson(dto);
 
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
         LocalDateTime testCreatedAt = LocalDateTime.now();
         LocalDateTime testModifiedAt = LocalDateTime.now();
         SingleFreeBoardCommentResponse response = SingleFreeBoardCommentResponse.of(testContent,

--- a/src/test/java/tdd/groomingzone/comment/freeboardcomment/application/service/DeleteFreeBoardCommentServiceTest.java
+++ b/src/test/java/tdd/groomingzone/comment/freeboardcomment/application/service/DeleteFreeBoardCommentServiceTest.java
@@ -15,6 +15,7 @@ import tdd.groomingzone.comment.freeboardcomment.application.port.out.port.LoadF
 import tdd.groomingzone.comment.freeboardcomment.domain.FreeBoardComment;
 import tdd.groomingzone.member.application.port.out.LoadMemberPort;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 
@@ -66,14 +67,7 @@ class DeleteFreeBoardCommentServiceTest {
 
         given(loadFreeBoardPort.loadFreeBoardById(anyLong())).willReturn(freeBoardEntityQueryResult);
 
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         given(loadMemberPort.findMemberById(anyLong())).willReturn(writer);
 

--- a/src/test/java/tdd/groomingzone/comment/freeboardcomment/application/service/GetFreeBoardCommentServiceTest.java
+++ b/src/test/java/tdd/groomingzone/comment/freeboardcomment/application/service/GetFreeBoardCommentServiceTest.java
@@ -17,6 +17,7 @@ import tdd.groomingzone.comment.freeboardcomment.application.port.out.port.LoadF
 import tdd.groomingzone.comment.freeboardcomment.domain.FreeBoardComment;
 import tdd.groomingzone.member.application.port.out.LoadMemberPort;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -87,14 +88,7 @@ class GetFreeBoardCommentServiceTest {
 
         given(loadFreeBoardPort.loadFreeBoardById(anyLong())).willReturn(freeBoardEntityQueryResult);
 
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
         given(loadMemberPort.findMemberById(anyLong())).willReturn(writer);
 
         FreeBoard freeBoard = FreeBoard.builder()

--- a/src/test/java/tdd/groomingzone/comment/freeboardcomment/application/service/PostFreeBoardCommentServiceTest.java
+++ b/src/test/java/tdd/groomingzone/comment/freeboardcomment/application/service/PostFreeBoardCommentServiceTest.java
@@ -16,6 +16,7 @@ import tdd.groomingzone.comment.freeboardcomment.application.port.out.port.SaveF
 import tdd.groomingzone.comment.freeboardcomment.domain.FreeBoardComment;
 import tdd.groomingzone.member.application.port.out.LoadMemberPort;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 
@@ -59,14 +60,7 @@ class PostFreeBoardCommentServiceTest {
 
         given(loadFreeBoardPort.loadFreeBoardById(anyLong())).willReturn(freeBoardEntityQueryResult);
 
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         given(loadMemberPort.findMemberById(anyLong())).willReturn(writer);
 

--- a/src/test/java/tdd/groomingzone/comment/freeboardcomment/application/service/PutFreeBoardCommentServiceTest.java
+++ b/src/test/java/tdd/groomingzone/comment/freeboardcomment/application/service/PutFreeBoardCommentServiceTest.java
@@ -17,6 +17,7 @@ import tdd.groomingzone.comment.freeboardcomment.application.port.out.port.SaveF
 import tdd.groomingzone.comment.freeboardcomment.domain.FreeBoardComment;
 import tdd.groomingzone.member.application.port.out.LoadMemberPort;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 
@@ -71,14 +72,7 @@ class PutFreeBoardCommentServiceTest {
 
         given(loadFreeBoardPort.loadFreeBoardById(anyLong())).willReturn(freeBoardEntityQueryResult);
 
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         given(loadMemberPort.findMemberById(anyLong())).willReturn(writer);
 

--- a/src/test/java/tdd/groomingzone/integrationtest/SpringSecurityTest.java
+++ b/src/test/java/tdd/groomingzone/integrationtest/SpringSecurityTest.java
@@ -71,6 +71,7 @@ class SpringSecurityTest {
                 .nickName(nickName)
                 .phoneNumber(phoneNumber)
                 .roles(List.of("BARBER", "CUSTOMER"))
+                .provider("SERVER")
                 .build();
 
         MemberEntity createdMemberEntity = memberEntitiyRepository.save(memberEntity);

--- a/src/test/java/tdd/groomingzone/member/adapter/in/web/post/PostMemberControllerTest.java
+++ b/src/test/java/tdd/groomingzone/member/adapter/in/web/post/PostMemberControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 import tdd.groomingzone.member.adapter.dto.MemberApiDto;
 import tdd.groomingzone.member.application.port.in.MemberCommandResponse;
@@ -41,6 +42,9 @@ class PostMemberControllerTest {
     @MockBean
     private PostMemberUseCase postMemberUseCase;
 
+    @MockBean
+    private SecurityFilterChain oauth2SecurityFilterChain;
+
     @Test
     @DisplayName("정상적인 회원 가입 요청 테스트")
     void postMemberTest() throws Exception {
@@ -50,6 +54,7 @@ class PostMemberControllerTest {
         String nickName = "nickName";
         String phoneNumber = "010-1111-1111";
         String role = "BARBER";
+        String provider = "SERVER";
 
         MemberApiDto.Post postDto = MemberApiDto.Post.builder()
                 .email(email)
@@ -61,7 +66,7 @@ class PostMemberControllerTest {
 
         String content = gson.toJson(postDto);
 
-        MemberCommandResponse commandResponse = MemberCommandResponse.of(1L, email, nickName, phoneNumber, role);
+        MemberCommandResponse commandResponse = MemberCommandResponse.of(1L, email, nickName, phoneNumber, role, provider);
 
         given(postMemberUseCase.postMember(any())).willReturn(commandResponse);
 

--- a/src/test/java/tdd/groomingzone/member/application/service/PostMemberServiceTest.java
+++ b/src/test/java/tdd/groomingzone/member/application/service/PostMemberServiceTest.java
@@ -13,6 +13,7 @@ import tdd.groomingzone.member.application.port.in.command.PostMemberCommand;
 import tdd.groomingzone.member.application.port.out.LoadMemberPort;
 import tdd.groomingzone.member.application.port.out.SaveMemberPort;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.util.Optional;
 
@@ -46,14 +47,7 @@ class PostMemberServiceTest {
         String phoneNumber = "010-1111-1111";
         String role = "BARBER";
 
-        Member member = Member.builder()
-                .memberId(1L)
-                .email(email)
-                .password(password)
-                .phoneNumber(phoneNumber)
-                .nickName(nickName)
-                .role(role)
-                .build();
+        Member member = MemberCreator.createMember();
 
         given(saveMemberPort.save(any())).willReturn(member);
 

--- a/src/test/java/tdd/groomingzone/post/freeboard/adapter/in/web/DeleteFreeBoardControllerTest.java
+++ b/src/test/java/tdd/groomingzone/post/freeboard/adapter/in/web/DeleteFreeBoardControllerTest.java
@@ -1,13 +1,13 @@
 package tdd.groomingzone.post.freeboard.adapter.in.web;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 import tdd.groomingzone.post.freeboard.application.port.in.usecase.DeleteFreeBoardUseCase;
 
@@ -19,7 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static tdd.groomingzone.global.utils.ApiDocumentUtils.getRequestPreProcessor;
 import static tdd.groomingzone.global.utils.ApiDocumentUtils.getResponsePreProcessor;
 
-@WebMvcTest(controllers = DeleteFreeBoardController.class,
+@WebMvcTest(controllers = {DeleteFreeBoardController.class},
         excludeAutoConfiguration = {SecurityAutoConfiguration.class})
 @AutoConfigureRestDocs
 class DeleteFreeBoardControllerTest {
@@ -29,6 +29,9 @@ class DeleteFreeBoardControllerTest {
 
     @MockBean
     private DeleteFreeBoardUseCase deleteFreeBoardUseCase;
+
+    @MockBean
+    private SecurityFilterChain oauth2SecurityFilterChain;
 
     @Test
     @DisplayName("정상적인 게시글 삭제 요청 테스트")

--- a/src/test/java/tdd/groomingzone/post/freeboard/adapter/in/web/GetFreeBoardControllerTest.java
+++ b/src/test/java/tdd/groomingzone/post/freeboard/adapter/in/web/GetFreeBoardControllerTest.java
@@ -9,11 +9,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 import tdd.groomingzone.post.common.WriterInfo;
 import tdd.groomingzone.post.freeboard.application.port.in.FreeBoardEntityCommandResponse;
 import tdd.groomingzone.post.freeboard.application.port.in.usecase.GetFreeBoardUseCase;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -42,6 +44,9 @@ class GetFreeBoardControllerTest {
     @MockBean
     private GetFreeBoardUseCase getFreeBoardUseCase;
 
+    @MockBean
+    private SecurityFilterChain oauth2SecurityFilterChain;
+
     @Test
     @DisplayName("정상적인 게시글 조회 요청 테스트")
     void getFreeBoardTest() throws Exception {
@@ -50,14 +55,7 @@ class GetFreeBoardControllerTest {
         String testContent = "changedContent";
         long testId = 1L;
 
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         FreeBoardEntityCommandResponse testResponse = FreeBoardEntityCommandResponse.of(testId,
                 testTitle,

--- a/src/test/java/tdd/groomingzone/post/freeboard/adapter/in/web/GetFreeBoardPageControllerTest.java
+++ b/src/test/java/tdd/groomingzone/post/freeboard/adapter/in/web/GetFreeBoardPageControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 import tdd.groomingzone.post.common.WriterInfo;
 import tdd.groomingzone.post.freeboard.application.port.in.FreeBoardEntityCommandResponse;
@@ -16,6 +17,7 @@ import tdd.groomingzone.post.freeboard.application.port.in.FreeBoardPageCommandR
 import tdd.groomingzone.post.freeboard.application.port.in.usecase.GetFreeBoardPageUseCase;
 import tdd.groomingzone.global.pagedresponse.PageInfo;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -45,18 +47,14 @@ class GetFreeBoardPageControllerTest {
     @MockBean
     private GetFreeBoardPageUseCase getFreeBoardPageUseCase;
 
+    @MockBean
+    private SecurityFilterChain oauth2SecurityFilterChain;
+
     @Test
     @DisplayName("게시글 페이지 조회 요청 테스트")
     void getFreeBoardPageTest() throws Exception {
         // given
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         List<FreeBoardEntityCommandResponse> testCommandResponseList = new ArrayList<>();
 

--- a/src/test/java/tdd/groomingzone/post/freeboard/adapter/in/web/PostFreeBoardControllerTest.java
+++ b/src/test/java/tdd/groomingzone/post/freeboard/adapter/in/web/PostFreeBoardControllerTest.java
@@ -1,8 +1,7 @@
 package tdd.groomingzone.post.freeboard.adapter.in.web;
 
 import com.google.gson.Gson;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -11,12 +10,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 import tdd.groomingzone.post.common.WriterInfo;
 import tdd.groomingzone.post.freeboard.adapter.in.web.dto.FreeBoardApiDto;
 import tdd.groomingzone.post.freeboard.application.port.in.FreeBoardEntityCommandResponse;
 import tdd.groomingzone.post.freeboard.application.port.in.usecase.PostFreeBoardUseCase;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static tdd.groomingzone.global.utils.ApiDocumentUtils.getRequestPreProcessor;
 import static tdd.groomingzone.global.utils.ApiDocumentUtils.getResponsePreProcessor;
 
-@WebMvcTest(controllers = PostFreeBoardController.class,
+@WebMvcTest(controllers = {PostFreeBoardController.class},
         excludeAutoConfiguration = {SecurityAutoConfiguration.class})
 @AutoConfigureRestDocs
 class PostFreeBoardControllerTest {
@@ -44,15 +45,18 @@ class PostFreeBoardControllerTest {
     private Gson gson;
 
     @MockBean
+    private SecurityFilterChain oauth2SecurityFilterChain;
+
+    @MockBean
     private PostFreeBoardUseCase postFreeBoardUseCase;
 
     @Test
     @DisplayName("정상적인 게시글 등록 요청 테스트")
     void postFreeBoardTest() throws Exception {
         // given
-        long testId = 1L;
         String testTitle = "title";
         String testContent = "content";
+        long testId = 1;
 
         FreeBoardApiDto.Post testPost = FreeBoardApiDto.Post.builder()
                 .title(testTitle)
@@ -61,14 +65,7 @@ class PostFreeBoardControllerTest {
 
         String content = gson.toJson(testPost);
 
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         FreeBoardEntityCommandResponse testResponse = FreeBoardEntityCommandResponse.of(testId,
                 testTitle,

--- a/src/test/java/tdd/groomingzone/post/freeboard/adapter/in/web/PutFreeBoardControllerTest.java
+++ b/src/test/java/tdd/groomingzone/post/freeboard/adapter/in/web/PutFreeBoardControllerTest.java
@@ -10,12 +10,15 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
+import tdd.groomingzone.global.time.Time;
 import tdd.groomingzone.post.common.WriterInfo;
 import tdd.groomingzone.post.freeboard.adapter.in.web.dto.FreeBoardApiDto;
 import tdd.groomingzone.post.freeboard.application.port.in.FreeBoardEntityCommandResponse;
 import tdd.groomingzone.post.freeboard.application.port.in.usecase.PutFreeBoardUseCase;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 import tdd.groomingzone.util.StubTime;
 
 import java.time.LocalDateTime;
@@ -35,7 +38,7 @@ import static tdd.groomingzone.global.utils.ApiDocumentUtils.getRequestPreProces
 import static tdd.groomingzone.global.utils.ApiDocumentUtils.getResponsePreProcessor;
 
 
-@WebMvcTest(controllers = PutFreeBoardController.class,
+@WebMvcTest(controllers = {PutFreeBoardController.class},
         excludeAutoConfiguration = {SecurityAutoConfiguration.class})
 @AutoConfigureRestDocs
 class PutFreeBoardControllerTest {
@@ -47,7 +50,10 @@ class PutFreeBoardControllerTest {
     private Gson gson;
 
     @MockBean
-    private StubTime stubTime;
+    private SecurityFilterChain oauth2SecurityFilterChain;
+
+    @MockBean
+    Time stubTime;
 
     @MockBean
     private PutFreeBoardUseCase putFreeBoardUseCase;
@@ -67,14 +73,7 @@ class PutFreeBoardControllerTest {
 
         String content = gson.toJson(testPut);
 
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         stubTime = new StubTime(LocalDateTime.of(2023, 11, 28, 22, 30, 10));
 

--- a/src/test/java/tdd/groomingzone/post/freeboard/application/service/DeleteFreeBoardServiceTest.java
+++ b/src/test/java/tdd/groomingzone/post/freeboard/application/service/DeleteFreeBoardServiceTest.java
@@ -14,6 +14,7 @@ import tdd.groomingzone.post.freeboard.application.port.out.LoadFreeBoardPort;
 import tdd.groomingzone.post.freeboard.application.port.out.query.DeleteFreeBoardQuery;
 import tdd.groomingzone.member.application.port.out.LoadMemberPort;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 
@@ -41,14 +42,7 @@ class DeleteFreeBoardServiceTest {
     @DisplayName("게시글 삭제 테스트")
     void deleteTest() {
         //given
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         DeleteFreeBoardCommand deleteFreeBoardCommand = DeleteFreeBoardCommand.of(1L, 1L);
         FreeBoardEntityQueryResult entityQueryResult = FreeBoardEntityQueryResult.of(1L, "test", "content", 0, LocalDateTime.now(), LocalDateTime.now(), 1L);

--- a/src/test/java/tdd/groomingzone/post/freeboard/application/service/GetFreeBoardPageServiceTest.java
+++ b/src/test/java/tdd/groomingzone/post/freeboard/application/service/GetFreeBoardPageServiceTest.java
@@ -15,6 +15,7 @@ import tdd.groomingzone.post.freeboard.application.port.out.LoadFreeBoardPort;
 import tdd.groomingzone.global.pagedresponse.PageInfo;
 import tdd.groomingzone.member.application.port.out.LoadMemberPort;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -39,14 +40,7 @@ class GetFreeBoardPageServiceTest {
     @Test
     @DisplayName("자유 게시글 페이지를 읽어온다.")
     void testGetFreeBoardPage() {
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
         given(loadMemberPort.findMemberById(anyLong())).willReturn(writer);
 
         int testPageIndex = 0;

--- a/src/test/java/tdd/groomingzone/post/freeboard/application/service/GetFreeBoardServiceTest.java
+++ b/src/test/java/tdd/groomingzone/post/freeboard/application/service/GetFreeBoardServiceTest.java
@@ -13,6 +13,7 @@ import tdd.groomingzone.post.freeboard.application.port.out.LoadFreeBoardPort;
 import tdd.groomingzone.post.freeboard.application.port.out.SaveFreeBoardPort;
 import tdd.groomingzone.member.application.port.out.LoadMemberPort;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 
@@ -40,14 +41,7 @@ class GetFreeBoardServiceTest {
     @DisplayName("하나의 자유 게시글을 조회한다.")
     void testGetFreeBoard(){
         //given
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
         given(loadMemberPort.findMemberById(anyLong())).willReturn(writer);
 
         String testTitle = "title";

--- a/src/test/java/tdd/groomingzone/post/freeboard/application/service/PostFreeBoardServiceTest.java
+++ b/src/test/java/tdd/groomingzone/post/freeboard/application/service/PostFreeBoardServiceTest.java
@@ -13,6 +13,7 @@ import tdd.groomingzone.post.freeboard.application.port.out.SaveFreeBoardPort;
 import tdd.groomingzone.post.freeboard.application.port.out.query.SaveFreeBoardQuery;
 import tdd.groomingzone.member.application.port.out.LoadMemberPort;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 
@@ -37,14 +38,7 @@ class PostFreeBoardServiceTest {
     @DisplayName("자유 게시글을 저장한다.")
     void testPostFreeBoard(){
         //given
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         String testTitle = "title";
         String testContent = "content";

--- a/src/test/java/tdd/groomingzone/post/freeboard/application/service/PutFreeBoardServiceTest.java
+++ b/src/test/java/tdd/groomingzone/post/freeboard/application/service/PutFreeBoardServiceTest.java
@@ -14,6 +14,7 @@ import tdd.groomingzone.post.freeboard.application.port.out.SaveFreeBoardPort;
 import tdd.groomingzone.post.freeboard.application.port.out.query.SaveFreeBoardQuery;
 import tdd.groomingzone.member.application.port.out.LoadMemberPort;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 
@@ -41,14 +42,7 @@ class PutFreeBoardServiceTest {
     @DisplayName("자유 게시글을 수정한다.")
     void testPutFreeBoard(){
         //given
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         String testTitle = "title";
         String testContent = "content";

--- a/src/test/java/tdd/groomingzone/post/freeboard/domain/FreeBoardTest.java
+++ b/src/test/java/tdd/groomingzone/post/freeboard/domain/FreeBoardTest.java
@@ -3,6 +3,7 @@ package tdd.groomingzone.post.freeboard.domain;
 import org.junit.jupiter.api.Test;
 import tdd.groomingzone.global.exception.BusinessException;
 import tdd.groomingzone.member.domain.Member;
+import tdd.groomingzone.util.MemberCreator;
 import tdd.groomingzone.util.StubTime;
 
 import java.time.LocalDateTime;
@@ -14,14 +15,7 @@ class FreeBoardTest {
 
     @Test
     void testModify() {
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         FreeBoard testEntity = FreeBoard.builder()
                 .id(1L)
@@ -46,14 +40,7 @@ class FreeBoardTest {
 
     @Test
     void testViewed() {
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         int viewCount = 0;
 
@@ -74,14 +61,7 @@ class FreeBoardTest {
 
     @Test
     void testCheckMemberAuthority() {
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         FreeBoard testEntity = FreeBoard.builder()
                 .id(1L)
@@ -100,6 +80,7 @@ class FreeBoardTest {
                 .phoneNumber("010-2211-1111")
                 .nickName("nickName22")
                 .role("CUSTOMER")
+                .provider("SERVER")
                 .build();
 
         assertThrows(BusinessException.class,() -> testEntity.checkMemberAuthority(otherMember));

--- a/src/test/java/tdd/groomingzone/post/recruitment/adapter/in/web/PostRecruitmentControllerTest.java
+++ b/src/test/java/tdd/groomingzone/post/recruitment/adapter/in/web/PostRecruitmentControllerTest.java
@@ -10,11 +10,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 import tdd.groomingzone.member.domain.Member;
 import tdd.groomingzone.post.common.WriterInfo;
 import tdd.groomingzone.post.recruitment.application.port.in.SingleRecruitmentResponse;
 import tdd.groomingzone.post.recruitment.application.port.in.usecase.PostRecruitmentUseCase;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -44,6 +46,9 @@ class PostRecruitmentControllerTest {
     @MockBean
     private PostRecruitmentUseCase postRecruitmentUseCase;
 
+    @MockBean
+    private SecurityFilterChain oauth2SecurityFilterChain;
+
     @Test
     @DisplayName("구인 구직 게시글을 등록한다.")
     void testPostRecruitment() throws Exception {
@@ -61,14 +66,7 @@ class PostRecruitmentControllerTest {
 
         String content = gson.toJson(testPost);
 
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         SingleRecruitmentResponse testResponse = SingleRecruitmentResponse.of(testId,
                 testTitle,

--- a/src/test/java/tdd/groomingzone/post/recruitment/application/service/PostRecruitmentServiceTest.java
+++ b/src/test/java/tdd/groomingzone/post/recruitment/application/service/PostRecruitmentServiceTest.java
@@ -13,6 +13,7 @@ import tdd.groomingzone.post.recruitment.application.port.in.command.PostRecruit
 import tdd.groomingzone.post.recruitment.application.port.out.RecruitmentEntityQueryResult;
 import tdd.groomingzone.post.recruitment.application.port.out.SaveRecruitmentPort;
 import tdd.groomingzone.post.recruitment.application.port.out.SaveRecruitmentQuery;
+import tdd.groomingzone.util.MemberCreator;
 
 import java.time.LocalDateTime;
 
@@ -37,14 +38,7 @@ class PostRecruitmentServiceTest {
     @DisplayName("구인구직 게시글을 저장한다")
     void testPostRecruitment() {
         //given
-        Member writer = Member.builder()
-                .memberId(1L)
-                .email("test@email.com")
-                .password("11aA!!@@Password")
-                .phoneNumber("010-1111-1111")
-                .nickName("nickName")
-                .role("BARBER")
-                .build();
+        Member writer = MemberCreator.createMember();
 
         String testTitle = "title";
         String testContent = "content";

--- a/src/test/java/tdd/groomingzone/util/MemberCreator.java
+++ b/src/test/java/tdd/groomingzone/util/MemberCreator.java
@@ -1,0 +1,18 @@
+package tdd.groomingzone.util;
+
+import tdd.groomingzone.member.domain.Member;
+
+public class MemberCreator {
+
+    public static Member createMember(){
+        return Member.builder()
+                .memberId(1L)
+                .email("test@email.com")
+                .password("11aA!!@@Password")
+                .phoneNumber("010-1111-1111")
+                .nickName("nickName")
+                .role("BARBER")
+                .provider("SERVER")
+                .build();
+    }
+}


### PR DESCRIPTION
## OAuth 회원 / 서버 회원 구분
- 회원 가입 시 provider를 설정하여 가입한 위치에 맞게 설정
- 각 써드파티는 이름(naver, kakao, google) / 서버 가입은 server로 정의

## 회원 객체 및 댓글 객체 생성 시 생성 시간 등록
- 이에 따른 테스트 코드 수정

## OAuth 적용에 따른 API계층 테스트 클래스 MockBean등록
- 이거는 고쳐야 할 것 같은데...